### PR TITLE
Find store with unique code

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -1,6 +1,6 @@
 class StoresController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_store, only: [:show, :edit, :update, :destroy]
+  before_action :set_store, only: [ :show, :edit, :update, :destroy]
   before_action :authorize_store_owner, only: [:edit, :update, :destroy]
 
   def index
@@ -25,6 +25,10 @@ class StoresController < ApplicationController
       }
     end
     end
+    respond_to do |format|
+      format.json
+      format.html
+    end
   end
 
   def show
@@ -32,6 +36,12 @@ class StoresController < ApplicationController
     # Actions pour la vue show
   end
 
+  def render_store
+    @store = Store.find_by(unique_code: params[:unique_code].to_s)
+    authorize @store
+    render json: @store
+
+  end
   def new
     @store = current_user.stores.build
     authorize @store

--- a/app/javascript/controllers/store_controller.js
+++ b/app/javascript/controllers/store_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="store"
+export default class extends Controller {
+  static targets = ["info", "code"]
+  connect() {
+    this.codeTarget.outerHTML = '<input class=\"form-control string optional\" data-store-target=\"code\" type="text\" name=\"transaction[receiver]\" id=\"transaction_receiver\" data-action=\"keyup->store#complete\">'
+  }
+
+  complete() {
+    const url = `http://localhost:3000/stores/render/${this.codeTarget.value}`
+    fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'If-Unmodified-Since': 'Wed, 21 Oct 2015 07:28:00 GMT',
+      },
+    })
+    .then(response => response.json())
+    .then((data) => {
+      this.infoTarget.lastElementChild.innerHTML = ""
+      this.infoTarget.firstElementChild.innerHTML = `${data.name}`
+      this.infoTarget.lastElementChild.outerHTML = `<p>${data.address}</p>`
+      // console.log(Object.values(data.name).join(''));
+      // console.log(Object(data.stores[0]).address);
+    })
+  }
+}

--- a/app/policies/store_policy.rb
+++ b/app/policies/store_policy.rb
@@ -14,6 +14,10 @@ class StorePolicy < ApplicationPolicy
     true
   end
 
+  def render_store?
+    true
+  end
+
   def create?
     true
   end

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -39,6 +39,7 @@
         <div class="store-details-one">
           <p class="store-name"><%= link_to store.name, store %></p>
           <p><%= store.address %></p>
+          <p style="color: purple"><%= store.unique_code %></p>
         </div>
       <div class="store-details-two">
         <p class="card-text"><%= store.opening_time %></p>

--- a/app/views/stores/index.json.erb
+++ b/app/views/stores/index.json.erb
@@ -1,0 +1,37 @@
+{ "stores": [
+ <% @stores.each do |store| %>
+    {
+      "id": "<%= store.id %>",
+      "name": "<%= store.name %>",
+      "address": "<%= store.address %>",
+      "code": "<%= store.unique_code %>"
+      <% if store.id == 8 %>
+        }
+      <% else %>
+      },
+      <% end %>
+  <% end %>
+  ]
+}
+
+<%#
+{
+    "stores": [
+        {
+            "Name": "&quot;Store&quot;",
+            "Address": "&quot;Via Italia 18, 06024 Gubbio Perugia, Italy&quot;"
+        },
+        {
+            "Name": "&quot;Amico Mio Bar&quot;",
+            "Address": "&quot;Via Camillo Benso Conte Di Cavour 20, 10123 Turin Turin, Italy&quot;"
+        },
+        {
+            "Name": "&quot;LIDL&quot;",
+            "Address": "&quot;Via Giovanni Giolitti 7, 10123 Turin Turin, Italy&quot;"
+        },
+        {
+            "Name": "&quot;Calle de casa&quot;",
+            "Address": "&quot;Calle 112 40, 110111 Bogotá, Colombia&quot;"
+        }
+    ]
+} %>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -9,7 +9,8 @@
 
   <div class="field">
     <%= f.label "Store code" %>
-    <%= f.input :receiver, label: false %>
+    <%= f.input :receiver, label: false,
+    input_html: { data: { store_target: "code" }} %>
   </div>
 
   <div class="field">

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -8,5 +8,12 @@
     <% end %>
       </div>
     </div>
+<div id="none" data-controller="store">
 <h1 class="exchange-heading">How much do you want to collect?</h1>
 <%= render "form", transaction: @transaction %>
+
+<div data-store-target="info" class="hero" style="line-height: 20px; padding-top: 5px; padding-bottom: 5px; padding-left: 5px; padding-right: 5px">
+<p style="color: goldenrod; font-size: 18px; font-weight: bold"></p>
+<p  style="font-size: 18px; font-weight: 600; letter-spacing: 2px">Searching for a store..                      <i class="fa-solid fa-hourglass-half fa-spin-pulse"></i></p>
+</div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
   resources :currencies, only: [:new, :create]
   resources :stores, only: [:index, :show, :new, :create, :edit, :update, :destroy]
+  get "stores/render/:unique_code", to: "stores#render_store", as: "render_store"
   resources :transactions, only: [:new, :create, :edit, :update] do
     collection do
       post :proxy


### PR DESCRIPTION
- Created a new stimulus controller for the store page (transactions/new)
- Linked the store_controller.js on the _form for transactions
- New method on the store controller "render_store" to find the store with the unique_code 
- The method renders only the json file of the store
- Keyup event on the input field of the store code calling the API on "http://localhost:3000/stores/render/:unique_code"
- For now is working on localhost only, but I'll change it for production
- Created the index.json.erb for the stores as a test feel free to take a look how it works and how the index method has changed
- This index.json.erb can be visualized in postman to see how we can render the json manually
- Use => [this](https://jsonlint.com/) to test if the json written manually is working
- Added the unique code on the store card so it will be easy to retrieve it for test